### PR TITLE
feat(templates): Added parameter and functionality to allow custom templating

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -925,6 +925,7 @@ dependencies = [
  "serde",
  "serde_json",
  "thiserror",
+ "walkdir",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -18,7 +18,7 @@ clap = "4.5.54"
 cucumber = { version = "0.22.1", features = ["tracing"] }
 filenamify = "0.1.2"
 gherkin = { version = "0.15.0", features = ["serde"] }
-handlebars = { version = "6.3.1", features = ["rust-embed"] }
+handlebars = { version = "6.3.1", features = ["rust-embed","dir_source"] }
 rust-embed = { version = "8.6.0", features = ["tokio"] }
 serde = { version = "1.0.219", features = ["derive"] }
 tokio = { version = "1.44.1", features = ["full"] }

--- a/README.md
+++ b/README.md
@@ -11,6 +11,15 @@ You can use the commandline option --output-html-path to change the output
 path of the html files, default it uses the current directory where the tests
 are run.
 
+## Parameters usage
+```
+Usage: cargo test -- <Options>
+
+Options:
+    --output-html-path <PATH>       The output path of the generated HTML files.
+    --template <PATH>               The location of the files for templating.
+```
+
 ## Examples
 
 ### A simple gherkin feature file
@@ -83,10 +92,21 @@ Feature: outline
 
 Will produce the following [html output](https://marcofuykschot.github.io/cucumber-reporter/F13495275682151091117.html)
 
+## Templating
+Currenlty templating functions by using html with basic css.
+For templating, the [handlebars](https://docs.rs/handlebars/latest/handlebars/) rust crate is used.
+For an example to use it. Refer to the default template in the `templates/` folder.
 
 ## planned
-
 * direct pdf output
-* custom templating  custom templating
 * markdown in descriptions
 * doc stringsc stringsrings
+
+## References
+
+#### Cucumber
+* [Cucumber-rs book](https://cucumber-rs.github.io/cucumber/current/)
+#### Templating  
+* [Handlebars](https://docs.rs/handlebars/latest/handlebars/) - crate used.
+* [Handlebarsjs](https://handlebarsjs.com/guide/) - better guide for templating.
+

--- a/README.md
+++ b/README.md
@@ -12,7 +12,7 @@ path of the html files, default it uses the current directory where the tests
 are run.
 
 ## Parameters usage
-```
+```md
 Usage: cargo test -- <Options>
 
 Options:

--- a/justfile
+++ b/justfile
@@ -1,4 +1,3 @@
-
 all: build test docs
 
 build:
@@ -9,3 +8,6 @@ test:
 
 docs:
     cargo doc --no-deps --document-private-items
+
+test-template:
+    cargo test --test main -- --output-html-path docs/ --template-dir tests/template_dark_mode_example/

--- a/src/reporter.rs
+++ b/src/reporter.rs
@@ -6,8 +6,9 @@ use cucumber::{
     writer::Normalized,
 };
 use gherkin::{Examples, Feature, GherkinEnv, Scenario, Step};
-use handlebars::Handlebars;
+use handlebars::{DirectorySourceOptionsBuilder, Handlebars};
 use rust_embed::Embed;
+use std::path::PathBuf;
 use std::sync::Arc;
 use std::{
     collections::{HashMap, HashSet},
@@ -130,7 +131,20 @@ impl CucumberReporter {
 
     async fn finish(&mut self, args: &ReporterArgs) -> Result<()> {
         let mut templates = Handlebars::new();
-        templates.register_embed_templates::<HtmlTemplates>()?;
+        if let Some(path) =  &args.template {
+            if path.exists(){
+                templates.register_templates_directory(path.to_str().unwrap(),
+                    DirectorySourceOptionsBuilder
+                        ::default()
+                        .tpl_extension("")
+                        .build()?
+                    ).expect("Templates could not be registered, please validate the configuration");
+            } else {
+                panic!("Given path: {:?} is invalid", path.to_str());
+            }
+        } else {
+            templates.register_embed_templates::<HtmlTemplates>()?;
+        }
 
         let mut index_data = Vec::new();
 
@@ -405,7 +419,7 @@ fn write_html_file(args: &ReporterArgs, html: String, filename: String) -> Resul
         std::fs::create_dir_all(path)?;
         format!("{}/{}", path, filename)
     } else {
-        format!("{}", filename)
+        filename.to_string()
     };
     std::fs::write(&filename, &html)?;
     Ok(())
@@ -413,8 +427,13 @@ fn write_html_file(args: &ReporterArgs, html: String, filename: String) -> Resul
 
 #[derive(Args)]
 pub struct ReporterArgs {
+    /// The output path of the generated HTML files.
     #[arg(long = "output-html-path")]
     pub output_html_path: Option<String>,
+
+    /// The location of the files for templating.
+    #[arg(long = "template-dir")]
+    pub template: Option<PathBuf>,
 }
 
 impl Normalized for CucumberReporter {}

--- a/tests/main.rs
+++ b/tests/main.rs
@@ -2,6 +2,7 @@ use cucumber::{World, WriterExt, writer::Basic};
 use cucumber_reporter::CucumberReporter;
 use steps::test_steps::ReporterWorld;
 use tracing::level_filters::LevelFilter;
+
 use tracing_subscriber::{
     Layer,
     fmt::format::{self, Format},

--- a/tests/template_dark_mode_example/feature.html
+++ b/tests/template_dark_mode_example/feature.html
@@ -1,0 +1,6 @@
+<div>
+    <h1 class="title">{{name}}</h1>
+    <p class="desc">{{description}}</p>
+    {{{rules}}}
+    {{{scenarios}}}
+</div>

--- a/tests/template_dark_mode_example/index.html
+++ b/tests/template_dark_mode_example/index.html
@@ -1,0 +1,70 @@
+<!DOCTYPE html>
+<html>
+
+<head>
+    <style>
+        html {
+            /* Worst dark mode example ever */
+	        background-color: #2e2e2e;
+        }
+        body {
+            font-family: 'Helvetica', sans-serif;
+            margin: 20px;
+            color: #000000;
+        }
+        h1 {
+            color: #004080;
+            border-bottom: 1px solid #ccc;
+            padding-bottom: 5px;
+        }
+        p {
+            margin: 10px 0;
+            line-height: 1.5;
+        }
+        table {
+            border-collapse: collapse;
+            width: 100%;
+            margin: 2px 0;
+        }
+        th, td {
+            border: 1px solid #ddd;
+            padding: 2px;
+            text-align: left;
+        }
+        th {
+            background-color: #f2f2f2;
+        }
+      </style>
+</head>
+
+<body>
+    <table>
+        <thead>
+            <th>Feature</th>
+            <th>Rules</th>
+            <th>Scenarios</th>
+            <th>Steps</th>
+            <th>Errors</th>
+            <th>Skipped</th>
+        </thead>
+        <tbody>
+            {{#each features}}
+            <tr onclick="javascript:window.location.assign('{{link}}')">
+               <td>{{name}}</td>
+               <td>{{nr_rules}}</td>
+               <td>{{nr_scenarios}}</td>
+               <td>{{nr_steps}}</td>
+               <td>{{nr_errors}}</td>
+               <td>{{nr_skipped}}</td>
+            </tr>
+            {{#if description}}
+            <tr style="background-color: rgb(201, 201, 201);">
+                <td style="padding-left: 10px; font-size: smaller;" colspan="6">{{description}}</td>
+            </tr>
+            {{/if}}
+            {{/each}}
+        </tbody>
+    </table>
+<body>
+
+</html>

--- a/tests/template_dark_mode_example/outline.html
+++ b/tests/template_dark_mode_example/outline.html
@@ -1,0 +1,51 @@
+<h3 class="title">{{name}}</h3>
+<p class="desc">{{scenario_description}}</p>
+<table class="results">
+    <thead>
+        <tr class="row heading">
+            <th>Step</th>
+        </tr>
+    </thead>
+    <tbody>
+        {{#each steps }}
+        <tr class="row">
+            <td>
+                {{#if is_and }}
+                <span style="margin-left: 10px;"> {{step_type}} {{step_template}} </span>
+                {{else}}
+                {{step_type}} {{step_template}}
+                {{/if}}
+            </td>
+        </tr>
+        {{/each}}
+    </tbody>
+</table>
+
+{{#each examples}}
+<h4>Example {{name}}</h4>
+<p>{{description}}</p>
+<table class="results">
+    <thead>
+        {{#each headers}}
+        <th class="row heading">
+            {{this}}
+        </th>
+        {{/each}}
+        <th class="row heading">
+            Outcome
+        </th>
+    </thead>
+    <tbody>
+        {{#each rows}}
+        <tr class="row bg_{{example_state}}">
+            {{#each example}}
+            <td style="text-align: center">{{this}}</td>
+            {{/each}}
+            <td>
+                {{> steps.html}}
+            </td>
+        </tr>
+        {{/each}}
+    </tbody>
+</table>
+{{/each}}

--- a/tests/template_dark_mode_example/page.html
+++ b/tests/template_dark_mode_example/page.html
@@ -1,0 +1,80 @@
+<html>
+
+<head>
+    <style>
+        html {
+            /* Worst dark mode example ever */
+	        background-color: #2e2e2e;
+        }
+        .title { 
+            color: #004080;
+            border-bottom: 1px solid #ccc;
+            padding-bottom: 5px;
+        }
+
+        .desc {
+            margin: 10px 0;
+            line-height: 1.5;
+        }
+        .results {
+            border-collapse: collapse;
+            width: 100%;
+            margin: 2px 0;
+        }
+        .row {
+            border: 1px solid #ddd;
+            padding: 2px;
+            text-align: left;
+        }
+       .datatable {
+            border-collapse:collapse;
+            margin: 10px 0;
+        }
+        .datarow {
+            border: 1px solid burlywood;
+            text-align: center;
+        }
+        .datacell {
+            border: 1px solid burlywood;
+            padding: 5px;
+        }
+
+        .heading {
+            background-color: #f2f2f2;
+        }
+
+        .Failed {
+            color: firebrick
+        }
+
+        .Passed {
+            color: darkgreen
+        }
+
+        .NotRun {
+            color: dimgray;
+            font-style: italic;
+        }
+
+        .bg_Failed {
+            background: rgb(255, 255, 255);
+            background: radial-gradient(circle, rgba(255, 255, 255, 1) 75%, rgba(255, 0, 0, 1) 100%);
+            font-weight: bolder;
+        }
+
+        .bg_Passed {
+            color: darkgreen
+        }
+
+        .bg_NotRun {
+            color: dimgray;
+            font-style: italic;
+        }
+    </style>
+</head>
+
+<body>
+    {{{this}}}
+</body>
+
+</html>

--- a/tests/template_dark_mode_example/rule.html
+++ b/tests/template_dark_mode_example/rule.html
@@ -1,0 +1,6 @@
+<div>
+    <h2 class="title" >{{name}}</h2>
+    <p class="description">{{description}}</p>
+    <hr>
+    {{{scenarios}}}
+</div>

--- a/tests/template_dark_mode_example/scenario.html
+++ b/tests/template_dark_mode_example/scenario.html
@@ -1,0 +1,4 @@
+<h3 class="title">{{name}}</h3>
+<p class="description">{{description}}</p>
+{{> steps.html }}
+<hr>

--- a/tests/template_dark_mode_example/steps.html
+++ b/tests/template_dark_mode_example/steps.html
@@ -1,0 +1,37 @@
+<table class="results">
+    <thead>
+        <tr class="row heading">
+            <th>Step</th>
+            <th>Outcome</th>
+        </tr>
+    </thead>
+    <tbody>
+        {{#each steps }}
+        <tr class="row {{step_state}}" >
+            <td>
+                {{#if (eq step_type "And") }}
+                <span style="margin-left: 10px;"> {{step_type}} {{step_template}} </span>
+                {{else}}
+                {{step_type}} {{step_template}}
+                {{/if}}
+                {{#if step_table }}
+                <table class="datatable" style="margin-left: 10px;">
+                   {{#each step_table }}
+                    <tr class="datarow">
+                       {{#each this }}
+                         <td class="datacell">
+                            {{this}}
+                         </td>
+                       {{/each}}
+                    </tr>
+                   {{/each}} 
+                </table>
+                {{/if}}
+            </td>
+            <td>
+                {{step_state}}
+            </td>
+        </tr>
+        {{/each}}
+    </tbody>
+</table>


### PR DESCRIPTION
Changes that are made:
* Added `template-dir` parameter and checks to validate a custom template folder
* Added more documentation to the `README.md`
* Removed templating todo
* Added justfile example for custom templating
* Added bad dark mode example to prove the point of custom templating